### PR TITLE
fix typeAdapers being unknown in deep fromJson/get calls

### DIFF
--- a/src/main/java/blue/endless/jankson/impl/Marshaller.java
+++ b/src/main/java/blue/endless/jankson/impl/Marshaller.java
@@ -147,6 +147,9 @@ public class Marshaller {
 		} else if (elem instanceof JsonObject) {
 			if (clazz.isPrimitive()) return null;
 			
+			JsonObject obj = (JsonObject) elem;
+			obj.setMarshaller(this);
+
 			if (typeAdapters.containsKey(clazz)) {
 				return (T) typeAdapters.get(clazz).apply((JsonObject) elem);
 			}


### PR DESCRIPTION
seems like the marshaller did not get set , so any putDefault / get calls in type adapters failed because the type adapter map was empty