### PR TITLE
Fix trailing spaces with printCommas(false) and spurious indentation with multiline comments and bareRootObject(true)

### DIFF
--- a/src/main/java/blue/endless/jankson/JsonArray.java
+++ b/src/main/java/blue/endless/jankson/JsonArray.java
@@ -154,7 +154,7 @@ public class JsonArray extends JsonElement implements List<JsonElement>, Iterabl
 	
 	@Override
 	public void toJson(Writer writer, JsonGrammar grammar, int depth) throws IOException {
-		int effectiveDepth = (grammar.bareRootObject) ? Math.max(depth-1,0) : depth;
+		int effectiveDepth = (grammar.bareRootObject) ? depth-1 : depth;
 		//int nextDepth = (grammar.bareRootObject) ? depth-1 : depth; 
 		
 		writer.append("[");

--- a/src/main/java/blue/endless/jankson/JsonObject.java
+++ b/src/main/java/blue/endless/jankson/JsonObject.java
@@ -214,7 +214,7 @@ public class JsonObject extends JsonElement implements Map<String, JsonElement> 
 	public void toJson(Writer w, JsonGrammar grammar, int depth) throws IOException {
 		//StringBuilder builder = new StringBuilder();
 		boolean skipBraces = depth==0 && grammar.bareRootObject;
-		int effectiveDepth = (grammar.bareRootObject) ? Math.max(depth-1,0) : depth;
+		int effectiveDepth = (grammar.bareRootObject) ? depth-1 : depth;
 		int nextDepth = (grammar.bareRootObject) ? depth : depth+1; 
 		
 		if (!skipBraces) {
@@ -236,7 +236,7 @@ public class JsonObject extends JsonElement implements Map<String, JsonElement> 
 				}
 			}
 			
-			CommentSerializer.print(w, entry.getComment(), Math.max(effectiveDepth,0), grammar);
+			CommentSerializer.print(w, entry.getComment(), effectiveDepth, grammar);
 			
 			boolean quoted = !grammar.printUnquotedKeys;
 			
@@ -256,7 +256,7 @@ public class JsonObject extends JsonElement implements Map<String, JsonElement> 
 					w.append(",");
 					if (i<entries.size()-1 && !grammar.printWhitespace) w.append(' ');
 				}
-			} else {
+			} else if (!grammar.printWhitespace) {
 				w.append(" ");
 			}
 			

--- a/src/main/java/blue/endless/jankson/impl/serializer/CommentSerializer.java
+++ b/src/main/java/blue/endless/jankson/impl/serializer/CommentSerializer.java
@@ -44,6 +44,7 @@ public class CommentSerializer {
 		print(builder, comment, indent, comments, whitespace);
 	}
 		
+	// Note: Indent may be -1.
 	public static void print(StringBuilder builder, String comment, int indent, boolean comments, boolean whitespace) {
 		if (!comments) return;
 		if (comment==null || comment.trim().isEmpty()) return;

--- a/src/test/java/blue/endless/jankson/TestCosmetic.java
+++ b/src/test/java/blue/endless/jankson/TestCosmetic.java
@@ -84,4 +84,30 @@ public class TestCosmetic {
 		Assert.assertEquals(expectedStrict, strict);
 		Assert.assertEquals(expectedRootArray, rootArray);
 	}
+	
+	@Test
+	public void testBareRootObjectIndentWithComment() {
+		String expectedJkson =
+				"/* This is a multiline\n" +
+				"   comment.\n" +
+				"*/\n" +
+				"object: {\n" +
+				"\tfoo: true\n" +
+				"}\n";
+		
+		JsonObject subject = new JsonObject();
+		JsonObject sub = new JsonObject();
+		
+		sub.put("foo", JsonPrimitive.TRUE);
+		
+		subject.put("object", sub, "This is a multiline\ncomment.\n");
+		
+		Assert.assertEquals(expectedJkson, subject.toJson(JsonGrammar.builder()
+				.bareRootObject(true)
+				.printCommas(false)
+				.withComments(true)
+				.printWhitespace(true)
+				.printUnquotedKeys(true)
+				.build()));
+	}
 }


### PR DESCRIPTION
As discussed in Matrix.