### PR TITLE
Fix compiling on Windows by setting UTF-8 encoding for javac

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ if (System.env.BUILD_NUMBER) {
 	versionSuffix = '-'+System.env.BUILD_NUMBER;
 }
 
+tasks.withType(JavaCompile) {
+	options.encoding = "UTF-8"
+}
+
 publishing {
 	publications {
 		mavenPrimary(MavenPublication) {


### PR DESCRIPTION
Prevents a compilation error when compiling the tests that use character escapes incompatible with Windows' char encoding.