### PR TITLE
Fix annotated Deserializer methods taking a Marshaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ build/
 .project
 .settings
 bin/
+.idea/
 
 # gradle
 !gradle-wrapper.jar

--- a/src/main/java/blue/endless/jankson/impl/POJODeserializer.java
+++ b/src/main/java/blue/endless/jankson/impl/POJODeserializer.java
@@ -282,7 +282,7 @@ public class POJODeserializer {
 			//return null;
 		} else if (params.length==2) {
 			//if (params[0].getClass().isAssignableFrom(sourceClass)) {
-				if (params[1].getClass().equals(blue.endless.jankson.api.Marshaller.class)) {
+				if (params[1].getType().equals(blue.endless.jankson.api.Marshaller.class)) {
 					return (Object o, blue.endless.jankson.api.Marshaller marshaller)->{
 						try {
 							return (B)m.invoke(null, o, marshaller);

--- a/src/test/java/blue/endless/jankson/TestDeserializer.java
+++ b/src/test/java/blue/endless/jankson/TestDeserializer.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import blue.endless.jankson.api.annotation.Deserializer;
 import blue.endless.jankson.api.Jankson;
 import blue.endless.jankson.api.JsonGrammar;
+import blue.endless.jankson.api.Marshaller;
 import blue.endless.jankson.api.SyntaxError;
 import blue.endless.jankson.api.element.JsonArray;
 import blue.endless.jankson.api.element.JsonElement;
@@ -59,8 +60,9 @@ public class TestDeserializer {
 			return result;
 		}
 		
+		// the unused Marshaller parameter is for testing that it gets recognised properly
 		@Deserializer
-		public static Foo deserialize(JsonArray arr) throws DeserializationException {
+		public static Foo deserialize(JsonArray arr, Marshaller marshaller) throws DeserializationException {
 			if (arr.size()<1 || arr.size()>2) throw new DeserializationException("Array can have either 1 or 2 elements. Found: "+arr.size());
 			Foo result = new Foo();
 			result.value = arr.getString(0, "OOPS");


### PR DESCRIPTION
The code checked `params[1].getClass()` (as in `Object.getClass()`) instead of `params[1].getType()`, which would always fail.