### PR TITLE
[Docs] Quirks documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,16 @@
-# Jankson
-JSON / HJSON parser and preprocessor which preserves ordering and comments
+# [Jankson](https://falkreon.github.io/Jankson)
 
+JSON5 / HJSON parser and preprocessor that preserves ordering and comments
 
 Official Discord: https://discord.gg/tV6FYXE8QH
 
-## Json Quirks
+## [Json Quirks](https://falkreon.github.io/Jankson/quirks)
 
-The full set of JSON5 quirks are supported:
-```json5
-{
-  // comments
-  unquoted: 'and you can quote me on that',
-  singleQuotes: 'I can use "double quotes" here',
-  lineBreaks: "Look, Mom! \
-No \\n's!",
-  hexadecimal: 0xdecaf,
-  leadingDecimalPoint: .8675309, andTrailing: 8675309.,
-  positiveSign: +1,
-  trailingComma: 'in objects', andIn: ['arrays',],
-  "backwardsCompatible": "with JSON",
-}
-```
+The full list of JSON5 quirks, and several HJSON quirks are supported.
 
-The following hjson quirks are supported:
+A full list of supported quirks is available [on the wiki](https://falkreon.github.io/Jankson/quirks)!
 
-```hjson
-{
-  # use #, // or /**/ comments,
-  // omit quotes for keys
-  key: 1,
-  // omit commas at the end of a line
-  cool: {
-    foo: 1
-    bar: 2
-  }
-  // allow trailing commas
-  list: [
-    1,
-    2,
-  ]
-}
-
-```
-
-The following hjson quirks are **NOT** supported:
-```hjson
-{
-	// omit quotes for strings - these will never be supported by jankson
-	// this is because other quirks require parsing out unquoted line text
-	contains: everything on this line
-
-	// use multiline strings - support is planned but isn't complete yet.
-	realist:
-	    '''
-	    My half empty glass,
-	    I will fill your empty half.
-	    Now you are half full.
-	    '''
-}
-```
-
-The following supported quirks are unique to jankson:
-```json5
-{
-	//Missing commas are fine anywhere
-	key: 1 key2: 2 key3: 3
-	items: [4 3 2 1 6 2 {foo: 'cool'} false]
-
-
-}
-```
-
-## Compiling
+## [Compiling](https://falkreon.github.io/Jankson/getting_started)
 
 NOTE: This artifact isn't on MavenCentral yet! Check the 1.8 branch or [the docs](https://falkreon.github.io/Jankson/)
 for code you can get from MavenCentral right now.
@@ -87,9 +26,13 @@ dependencies {
 ```
 
 ## Using
-Jankson is, for the most part, a drop-in replacement for Gson or HJson, but can also be
-used as a preprocessor to fix quirks and strip comments, rebaking it into standard JSON
+
+Jankson is, for the most part, a drop-in replacement for [Gson] or [Hjson], but can also be
+used as a preprocessor to fix quirks and strip comments, re-baking it into standard JSON
 syntax for another parser to consume.
+
+[Gson]:https://github.com/Google/Gson
+[Hjson]:https://github.com/hjson/hjson-java
 
 ```java
 try {
@@ -117,39 +60,14 @@ try {
 }
 ```
 
-
-
-This processor produces reliable behavior when encountering many quirks which are normal
-for configuration files:
-
-* Comments, normally disallowed in json, are completely legal, inspectable, and preserved
-  across re-saves of the file.
-  
-* Missing or extra commas. These are completely ignored, allowing smaller config file
-  diffs when object or array elements are added or removed. This also protects end-users
-  from some hard-to-notice syntax errors, and eliminates the need for lengthy restarts
-  because the user intent was clear.
-  
-* Unquoted object keys. This is a very common quirk, and as usual the user intent is very
-  clear in these cases.
-
-This processor will reliably produce descriptive errors for certain other quirks:
-
-* Unmatched quotes are completely ambiguous. The amount of text captured may have greatly
-  exceeded the size of the intended quotation, possibly even running into the end of the
-  stream. This constitutes a macro-structural ambiguity and must be addressed by the user
-  
-* Unmatched braces are direct structural ambiguities. One might be able to recover the
-  user's intent from indentation, but for unknown input where the indentation may have
-  been clobbered or minified, we can't assume good faith and must ask the user to clarify.
-
 ## Displaying errors  
 
 In nearly any case where the processor can't accept the input, the SyntaxError subclass is
 capable of producing a String which describes both the line and character that the element
-started parsing at, and the line and character where the error was discovered. When
-presenting a SyntaxError to the user, it's strongly reccommended that the stack trace is
-ommitted, and instead two lines are printed: the exception's ```getMessage()```, followed by its
-```getLineMessage()```. This will give the user the most relevant information available about
-how to fix the problem. If multiple json files are being parsed, it may also be necessary
-to indicate the name and/or path to the file so that the problem can be located.
+started parsing at, and the line and character where the error was discovered.<br>
+When presenting a SyntaxError to the user, it's strongly recommended that the stack trace is
+omitted, and instead two lines are printed: the exception's `getMessage()`, followed by its
+`getLineMessage()`.<br>
+This will give the user the most relevant information available about how to fix the problem.
+If multiple JSON files are being parsed, it may also be necessary to indicate the name and/or path to the file
+so that the problem can be located.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,26 @@
 
 Welcome to the Jankson wiki.
 
-Users: If you need a copy of Jankson it should have been included with your program,
-but you can find the latest [releases on GitHub].
+## What is Jankson?
 
-Developers: To get started using Jankson, head over to the [Getting Started] page.
+Jankson is a [JSON5] / [HJSON] parser and preprocessor that preserves ordering and comments.
+
+## Where do I get it?
+
+**Users:** Jankson should have been included with your program.
+If you need a copy, you can find the latest [releases on GitHub].
+
+**Developers:** To get started using Jankson, head over to the [Getting Started] page.
+
+## How is it different from other JSON libraries?
+
+Jankson supports a list of "[quirks]" that extend the JSON format,
+such as comments and unquoted keys.
+
+These quirks mostly come from the [JSON5] and [HJSON] specifications.
 
 [releases on GitHub]:https://github.com/falkreon/Jankson/releases
 [Getting Started]:getting_started.md
+[JSON5]:https://json5.org/
+[HJSON]:https://hjson.github.io/#intro
+[quirks]:./quirks.md

--- a/docs/quirks.md
+++ b/docs/quirks.md
@@ -1,0 +1,117 @@
+# JSON Quirks
+
+Jankson produces reliable behavior when encountering many quirks
+which are normal for configuration files:
+
+* Comments<br>
+  Normally disallowed in JSON, but completely legal, inspectable,
+  and preserved across re-saves of the file with Jankson.
+
+* Missing or extra commas<br>
+  These are completely ignored, allowing smaller config file
+  diffs when object or array elements are added or removed.
+  This also protects end-users from some hard-to-notice syntax errors,
+  and eliminates the need for lengthy restarts because the user intent was clear.
+
+* Unquoted object keys<br>
+  This is a very common quirk, and as usual, the user's intent is very clear in these cases.
+
+Jankson will also reliably produce descriptive errors for certain other quirks:
+
+* Unmatched quotes are completely ambiguous.
+  The amount of text captured may have greatly exceeded the size of the intended quotation,
+  possibly even running into the end of the stream.
+  This constitutes a macro-structural ambiguity and must be addressed by the user.
+
+* Unmatched braces are direct structural ambiguities.
+  One might be able to recover the user's intent from indentation,
+  but for unknown input where the indentation may have been clobbered or minified,
+  we can't assume good faith and must ask the user to clarify.
+
+
+???+ info "JSON5"
+    The full set of JSON5 quirks are supported. And it's backward-compatible with JSON.
+
+    === "Supported"
+        - Unquoted keys
+        - `'` Single-quotes (apostrophes) around values
+        - `\` Line-breaks
+        - `.` Leading / trailing decimal points in values
+        - `+` Positive signs before values
+        - `0x` Hexadecimal values
+        - `#` `//` `/**/` Comments
+
+    ??? info "Example"
+        ```
+        {
+          // comments
+          unquotedKey: 'and you can quote me on that',
+          singleQuotes: 'I can use "double quotes" here',
+          lineBreaks: "Look, Mom! \
+        No \\n's!",
+          hexadecimal: 0xdecaf,
+          leadingDecimalPoint: .8675309, andTrailing: 8675309.,
+          positiveSign: +1,
+          trailingComma: 'in objects', andIn: ['arrays',],
+          "backwardsCompatible": "with JSON",
+        }
+        ```
+
+???+ info "HJSON"
+    A selection of HJSON quirks are supported.
+
+    === "Supported"
+        - Unquoted keys
+        - Omitted commas at the end of lines
+        - `,` Trailing commas
+        - `#` `//` `/**/` Comments
+
+        ??? info "Example"
+            ```
+            {
+              # omit quotes for keys
+              key: 1,
+              // omit commas at the end of a line
+              cool: {
+              foo: 1
+              bar: 2
+            }
+              /* allow trailing commas */
+              list: [
+                1,
+                2,
+              ]
+            }
+            ```
+    === "NOT supported"
+        - Unquoted string values
+            - These will *NEVER* be supported by Jankson.<br>
+              This is because other quirks require parsing out unquoted line text.
+        - Multi-line block strings
+            - Support is planned but incomplete.
+        
+        ??? info "Example"
+            ```
+            {
+              unquotedValue: this value has no quotes
+              multiLineStrings:
+                  '''
+                  My half empty glass,
+                  I will fill your empty half.
+                  Now you are half full.
+                  '''
+            }
+            ```
+
+???+ info "ONLY in Jankson"
+    Some quirks are unique to Jankson.
+
+    - Omitting commas is fine *anywhere*!
+
+    ??? info "Example"
+        ```
+        {
+            key1: 1 key2: 2 key3: 3
+            items: [4 3 2 1 6 2 { foo: 'cool' } false]
+        }
+        ```

--- a/docs/v1/custom_serialization.md
+++ b/docs/v1/custom_serialization.md
@@ -5,12 +5,12 @@ Suppose you have an object that's not straightforward like a POJO, and you want 
 In this example, Class A may contain information about either an array or an instance of Class B.
 We only want to serialize one of them at a time. The other will always be null.
 
-=== "Classes"
+=== "Java Example"
     !!! note inline "ClassA.java"
         ```java
         --8<-- "v1/snippets/non_pojo_a.java"
         ```
-    !!! note "ClassB.java"
+    !!! note inline "ClassB.java"
         ```java
         --8<-- "v1/snippets/non_pojo_b.java"
         ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
   - Home:
       - 'index.md'
       - "Getting Started": 'getting_started.md'
+      - "Quirks": 'quirks.md'
   - 1.2.x:
       - "Loading POJOs": "v1/loading_pojos.md"
       - "Combine with Gson/Jackson": "v1/jankson_preprocessor.md"


### PR DESCRIPTION
Moves the Quirks documentation from the ReadMe to its own pretty little page on the wiki.

I also edited the ReadMe to encourage viewers to visit the wiki, and fixed that run-on paragraph that should probably get its own Wiki page later on.