### PR TITLE
[Docs] Fix inconsistent Maven scopes in tutorial

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -36,7 +36,7 @@ Then you can add the dependency itself.
     ```groovy
     dependencies {
         // Other dependencies
-        compile "blue.endless:jankson:x.y.z"
+        implementation "blue.endless:jankson:x.y.z"
     }
     ```
 === "Kotlin DSL"


### PR DESCRIPTION
Now they're all `implementation`.

...I hope. I mean I don't actually know what the default scope in Apache Maven is.