### PR TITLE
[2.x] Update Java version in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,12 @@ group = "blue.endless";
 archivesBaseName = "Jankson";
 version = "2.0.0-alpha.2";
 
-sourceCompatibility = 1.17;
-targetCompatibility = 1.17;
-
 repositories {
 	mavenCentral();
+}
+
+java {
+	sourceCompatibility = targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {


### PR DESCRIPTION
Updates the Java version in build.gradle to match the wrapper version.

Missing this causes a build failure when using IntelliJ as the build system rather than Gradle, due to Java 21 features being used in several places.
