### PR TITLE
Simplify and clean up Gradle buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,11 @@ plugins {
 }
 
 group = "blue.endless";
-archivesBaseName = "Jankson";
 version = "2.0.0-alpha.3";
+
+base {
+	archivesName = "Jankson";
+}
 
 repositories {
 	mavenCentral();

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,10 @@
-buildscript {
-	repositories {
-		mavenCentral();
-		maven {
-			name = "sonatype";
-			url = "https://oss.sonatype.org/content/repositories/snapshots/";
-		}
-		maven {
-			url "https://plugins.gradle.org/m2/";
-		}
-	}
-}
-
 plugins {
+	id 'java'
+	id 'eclipse'
+	id 'maven-publish'
+	id 'signing'
 	id 'org.cadixdev.licenser' version '0.6.1'
 }
-
-apply plugin: "java";
-apply plugin: "eclipse";
-apply plugin: "maven-publish";
-apply plugin: "signing";
 
 group = "blue.endless";
 archivesBaseName = "Jankson";

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ repositories {
 
 java {
 	sourceCompatibility = targetCompatibility = JavaVersion.VERSION_21
+	withSourcesJar();
+	withJavadocJar();
 }
 
 jar {
@@ -24,17 +26,6 @@ jar {
 			"Automatic-Module-Name" : "jankson"
 		);
 	}
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-	archiveClassifier = "sources"
-	from sourceSets.main.allSource
-}
-
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-	archiveClassifier = "javadoc"
-	from javadoc.destinationDir
 }
 
 tasks.withType(org.gradle.api.tasks.javadoc.Javadoc) {
@@ -65,8 +56,6 @@ publishing {
 			groupId project.group;
 			artifactId "jankson";
 			version project.version+versionSuffix;
-			artifact sourcesJar;
-			artifact javadocJar;
 			
 			pom {
 				name = "Jankson";
@@ -130,7 +119,7 @@ if (file("private.gradle").exists()) {
 	apply from: "private.gradle";
 }
 
-defaultTasks "clean", "build", "sourcesJar";
+defaultTasks "clean", "build";
 
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ jar {
 	}
 }
 
-tasks.withType(Javadoc) {
+tasks.withType(Javadoc).configureEach {
 	failOnError false
 	//options.addBooleanOption("Xdoclint:none", true)
 	options.addStringOption("Xdoclint:none", "-quiet")
@@ -43,7 +43,7 @@ if (System.env.BUILD_NUMBER) {
 	versionSuffix += '-'+System.env.BUILD_NUMBER;
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
 	options.encoding = "UTF-8"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ jar {
 	}
 }
 
-tasks.withType(org.gradle.api.tasks.javadoc.Javadoc) {
+tasks.withType(Javadoc) {
 	failOnError false
 	//options.addBooleanOption("Xdoclint:none", true)
 	options.addStringOption("Xdoclint:none", "-quiet")


### PR DESCRIPTION
The individual commits have more details about what I did.

There's still one deprecation warning from Licenser (which uses a deprecated API), but I won't touch the plugin here. Some alternatives are [Spotless](https://github.com/diffplug/spotless/blob/7691b42913dd375b5496abdec6691ba12235ce56/plugin-gradle/README.md#license-header) and [Indra's licenser](https://github.com/KyoriPowered/indra/wiki/indra-licenser-spotless) which wraps around it. (I can recommend the latter - it's almost a drop-in replacement, you'd just need to set the license file name.)