### PR TITLE
Do not allow blank issues on GitHub.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This force peoples making issues to write a message in their issues so it's not completely empty.

This is to avoid low quality or spam issues.